### PR TITLE
Update installation.md

### DIFF
--- a/memory/mindforger/installation.md
+++ b/memory/mindforger/installation.md
@@ -46,9 +46,9 @@ Install MindForger from **PPA**.
 Add [my PPA](http://www.mindforger.com/debian), trust [GPG key](http://www.mindforger.com/gpgpubkey.txt) and 
 install MindForger:
 
-```
+```bash
 # add PPA to APT sources:
-sudo echo -e "\ndeb http://www.mindforger.com/debian stretch main" >> /etc/apt/sources.list
+sudo bash -c 'echo -e "\ndeb https://www.mindforger.com/debian stretch main" > /etc/apt/sources.list.d/mindforger.list'
 
 # import PPA's GPG key
 wget -qO - http://www.mindforger.com/gpgpubkey.txt | sudo apt-key add -


### PR DESCRIPTION
FD redirection (i.e., `>` and `>>`) is done at the shell level, not the application level. Therefore, `sudo echo foo > /etc/bar` will fail, as the shell isn't being elevated by `sudo`. The solution is to run the command inside an elevated shell, a la, `sudo bash -c 'echo foo > /etc/bar'`.

This commit wraps the command to add the repository to `/etc/apt/sources.list` as shown above.

Additionally, my change adds the repository to its own file, which is a best practice as it prevents cluttering the `sources.list` file.